### PR TITLE
Fixing parameter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Send command `cmd`
   power_off:       "ka 00 00"
   power_status:    "ka 00 ff"
   volume_get:      "kf 00 ff"
-  volume_set:      "kf 00 %g"
+  volume_set:      "kf 00 VAL"
   key_home:        "mc 00 7c"
   key_up:          "mc 00 40"
   ley_left:        "mc 00 07"
@@ -78,10 +78,10 @@ Send command `cmd`
   volume_up:       "mc 00 02"
   volume_down:     "mc 00 03"
 ```
-where  ` %g `  is  a numeric value from 00 to 64 sent as a parameter"
+where  ` VAL`  is  a numeric value from 00 to 64 sent as a  string parameter"
 
 #### Example with curl
-```curl  -X POST -H "Content-Type: application/json" -d '{"args":[64]}'   "http://localhost:8080/commands/volume_set"```
+```curl  -X POST -H "Content-Type: application/json" -d '{"args":["64"]}'   "http://localhost:8080/commands/volume_set"```
    
 
 ## License

--- a/drivers/lg/command.go
+++ b/drivers/lg/command.go
@@ -26,7 +26,7 @@ var cmds = map[Command]string{
 	PowerOffCmd:    "ka 00 00",
 	PowerStatusCmd: "ka 00 ff",
 	VolumeGetCmd:   "kf 00 ff",
-	VolumeSetCmd:   "kf 00 %g",
+	VolumeSetCmd:   "kf 00 %s",
 	KeyHome:        "mc 00 7c",
 	KeyUp:          "mc 00 40",
 	KeyLeft:        "mc 00 07",


### PR DESCRIPTION
The values in args should be a string to be correctly treat 

the correct now is
`curl  -X POST -H "Content-Type: application/json" -d '{"args":["64"]}'   "http://localhost:8080/commands/volume_set"`